### PR TITLE
fix: don't crash when item's Author is nil

### DIFF
--- a/ui/finder.go
+++ b/ui/finder.go
@@ -8,6 +8,22 @@ import (
 	"github.com/mmcdole/gofeed"
 )
 
+func bodyFromItem(item *gofeed.Item) string {
+	var author string
+	if item.Author != nil {
+		author = fmt.Sprintf("  by %s\n", item.Author.Name)
+	}
+
+	return fmt.Sprintf(
+		"■ %s\n\n%s  published at %s, updated at %s\n\n%s\n",
+		item.Title,
+		author,
+		item.Published,
+		item.Updated,
+		item.Description,
+	)
+}
+
 func FindItemMulti(items []*gofeed.Item) ([]int, error) {
 	return fuzzyfinder.FindMulti(
 		items,
@@ -18,15 +34,7 @@ func FindItemMulti(items []*gofeed.Item) ([]int, error) {
 			if i == -1 {
 				return ""
 			}
-			s := fmt.Sprintf(
-				"■ %s\n\n  by %s\n  published at %s, updated at %s\n\n%s\n",
-				items[i].Title,
-				items[i].Author.Name,
-				items[i].Published,
-				items[i].Updated,
-				items[i].Description,
-			)
-			return runewidth.Wrap(s, width/2-5)
+			return runewidth.Wrap(bodyFromItem(items[i]), width/2-5)
 		}),
 	)
 }
@@ -41,15 +49,7 @@ func FindItem(items []*gofeed.Item) (int, error) {
 			if i == -1 {
 				return ""
 			}
-			s := fmt.Sprintf(
-				"■ %s\n\n  by %s\n  published at %s, updated at %s\n\n%s\n",
-				items[i].Title,
-				items[i].Author.Name,
-				items[i].Published,
-				items[i].Updated,
-				items[i].Description,
-			)
-			return runewidth.Wrap(s, width/2-5)
+			return runewidth.Wrap(bodyFromItem(items[i]), width/2-5)
 		}),
 	)
 }

--- a/ui/pager.go
+++ b/ui/pager.go
@@ -126,15 +126,20 @@ func NewPager(item *gofeed.Item) (*tea.Program, error) {
 }
 
 func renderContent(item *gofeed.Item) string {
+	var author string
+	if item.Author != nil {
+		sprintfIfNotBlank("by %s ", item.Author.Name)
+	}
+
 	return fmt.Sprintf(
-		`%s %s %s
+		`%s%s %s
 ──────
 %s
 %s
 ──────
 %s
 `,
-		sprintfIfNotBlank("by %s", item.Author.Name),
+		author,
 		sprintfIfNotBlank("published at %s", item.Published),
 		sprintfIfNotBlank("updated at %s", item.Updated),
 		sprintfIfNotBlank("%s", item.Description),


### PR DESCRIPTION
Creating the item's body crashed when accessing `items[i].Author` without checking whether it's nil.