### PR TITLE
use empty slice when we cannot read URL entries

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,10 +95,7 @@ func initApp() *cli.App {
 					}
 					urls, err := readURLEntry()
 					if err != nil {
-						return cli.Exit(
-							fmt.Sprintf("failed to read URL entry file (%s)", url),
-							int(exitCodeErrURLEntry),
-						)
+						urls = []string{}
 					}
 					if !isUniqueURL(urls, url) {
 						return cli.Exit(


### PR DESCRIPTION
The first time this command is used, the user will see an error because it tries to read a `urls.txt` file that does not exist. This commit simply empties the array to avoid that.